### PR TITLE
Create new job id for each file executed.

### DIFF
--- a/app/src/main/java/com/termux/boot/BootJobService.java
+++ b/app/src/main/java/com/termux/boot/BootJobService.java
@@ -10,6 +10,9 @@ import android.os.PersistableBundle;
 
 public class BootJobService extends JobService {
 
+    public static final int TERMUX_BOOT_JOB_ID_BASE = 1000;
+    static int jobId = TERMUX_BOOT_JOB_ID_BASE;
+
     public static final String SCRIPT_FILE_PATH = "com.termux.boot.script_path";
 
     // Constants from TermuxService.
@@ -35,12 +38,16 @@ public class BootJobService extends JobService {
             context.startService(executeIntent);
         }
 
-        return true;
+        return false;
     }
 
     @Override
     public boolean onStopJob(JobParameters params) {
         return true;
+    }
+
+    public static int getNextId() {
+        return jobId++;
     }
 
 }

--- a/app/src/main/java/com/termux/boot/BootReceiver.java
+++ b/app/src/main/java/com/termux/boot/BootReceiver.java
@@ -46,7 +46,7 @@ public class BootReceiver extends BroadcastReceiver {
             extras.putString(BootJobService.SCRIPT_FILE_PATH, file.getAbsolutePath());
 
             ComponentName serviceComponent = new ComponentName(context, BootJobService.class);
-            JobInfo job = new JobInfo.Builder(0, serviceComponent)
+            JobInfo job = new JobInfo.Builder(BootJobService.getNextId(), serviceComponent)
                     .setExtras(extras)
                     .setOverrideDeadline(3 * 1000)
                     .build();


### PR DESCRIPTION
Updating from old 0.3 I've noticed that only single (e.g. from 01, 02, 03 only 03) script from ~/.termux/boot gets executed on boot. Looks like this is because scheduling jobs with same id just replaces the previous one, so only one job ends up starting and sending task to the termux service.