### PR TITLE
termux-boot is not working on Xiaomi Redmi 7A on Android 10

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/com/termux/boot/BootActivity.java
+++ b/app/src/main/java/com/termux/boot/BootActivity.java
@@ -1,7 +1,11 @@
 package com.termux.boot;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.webkit.WebView;
 
 import androidx.annotation.Nullable;
@@ -10,6 +14,19 @@ public class BootActivity extends Activity {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
+        // For details see:
+        // https://stackoverflow.com/a/63250729/
+        // https://www.reddit.com/r/tasker/comments/d7whyj/android_10_and_auto_starting_apps/
+        // https://stackoverflow.com/q/64642362/
+        // https://stackoverflow.com/a/19856267/
+        Context context = getApplicationContext();
+        int Q = 29; // Android 10 (the constant is missing here in Build.VERSION for SdkVersion 28)
+        if (Build.VERSION.SDK_INT >= Q) {
+            if (!Settings.canDrawOverlays(context)) {
+                startActivity(new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION));
+            }
+        }
+
         super.onCreate(savedInstanceState);
         WebView webView = new WebView(this);
         webView.loadUrl("file:///android_asset/overview.html");


### PR DESCRIPTION
This pull request is a fix for boot_completed is not working on Android 10

For details see:
https://stackoverflow.com/a/63250729/
https://www.reddit.com/r/tasker/comments/d7whyj/android_10_and_auto_starting_apps/
https://stackoverflow.com/q/64642362/
https://stackoverflow.com/a/19856267/

Related pull request for termux-app:
termux-app is not booted and not properly working in background on Android 10 (on Xiaomi Redmi 7A) 
https://github.com/termux/termux-app/pull/3870